### PR TITLE
Make get_lldp_neighbors/get_lldp_neighbors_detail working on old Cumulus version. Improving speed as well for those 2 getters.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ except AttributeError:
 
 setup(
     name="napalm-cumulus",
-    version="0.5.6",
+    version="0.5.7a4",
     packages=find_packages(),
     author="Arthur Halet",
     author_email="arthur.halet@orange.com",


### PR DESCRIPTION
Patching cumulus napalm driver to handle `get_lldp_neighbors` and `get_lldp_neighbors_detail` on older Cumulus Linux (at least cl3.3.2) which uses a different format of the [net show lldp json] output.

Improving a lot the speed for `get_lldp_neighbors` and `get_lldp_neighbors_detail` by avoiding to exec net show interface call for each interface found. A single call is made.

For a cl3.3.2 box with ~50 LLDP interfaces, it's 7times faster.
For a cl3.7.6 box with ~80 LLDP interfaces, it's 16times faster.

This PR might need some rework, I've opened it early to get your feedback first.
Thanks !
Nico


Signed-off-by: Nicolas Piatto <nicolas.piatto [ \aT] gandi.net>
Sponsored by gandi.net